### PR TITLE
Refactor+country filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,26 @@ AZURE_MAPS_API_KEY=your-key-here
 use Sacapsystems\LaravelAzureMaps\Facades\AzureMaps;
 
 // Get coordinates for an address (default limit is 5)
-$coordinates = AzureMaps::searchAddress('123 Main Street, Cape Town');
+$coordinates = AzureMaps::searchAddress('123 Main Street, Cape Town')
+            ->get();
 
 // Get coordinates with custom limit
-$coordinates = AzureMaps::searchAddress('123 Main Street, Cape Town', 2);
+$coordinates = AzureMaps::searchAddress('123 Main Street, Cape Town')
+            ->limit(3)
+            ->get();
+
+// Search multiple countries
+$results = AzureMaps::searchAddress('123 Main Street')
+            ->country(['ZA', 'NA', 'BW'])
+            ->get();
 
 // Search for schools (default limit is 5)
 $schools = AzureMaps::searchSchools('Cape Town High School');
 
 // Search for schools with custom limit
-$schools = AzureMaps::searchSchools('Cape Town High School', 2);
+$schools = AzureMaps::searchSchools('Cape Town High School')
+            ->limit(10)
+            ->get();
 ```
 
 ## Response Format

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ $results = AzureMaps::searchAddress('123 Main Street')
             ->get();
 
 // Search for schools (default limit is 5)
-$schools = AzureMaps::searchSchools('Cape Town High School');
+$schools = AzureMaps::searchSchools('Cape Town High School')
+            ->get();
 
 // Search for schools with custom limit
 $schools = AzureMaps::searchSchools('Cape Town High School')

--- a/src/Builders/QueryBuilder.php
+++ b/src/Builders/QueryBuilder.php
@@ -42,7 +42,10 @@ class QueryBuilder
         return $this;
     }
 
-    public function country(string|array $countryCode): self
+    /**
+     * @param string|array $countryCode
+     */
+    public function country($countryCode): self
     {
         $this->params['countrySet'] = is_array($countryCode)
             ? implode(',', $countryCode)

--- a/src/Builders/QueryBuilder.php
+++ b/src/Builders/QueryBuilder.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Sacapsystems\LaravelAzureMaps\Builders;
+
+use Illuminate\Support\Facades\Http;
+use Sacapsystems\LaravelAzureMaps\Exceptions\AzureMapsException;
+
+class QueryBuilder
+{
+    private array $params;
+    private string $baseUrl;
+    private string $apiKey;
+
+    private const DEFAULT_PARAMS = [
+        'api-version' => '1.0',
+        'limit' => 5
+    ];
+
+    public function __construct(string $baseUrl, string $apiKey)
+    {
+        $this->baseUrl = $baseUrl;
+        $this->apiKey = $apiKey;
+    }
+
+    public function newSearch(string $query, ?string $categorySet = null): self
+    {
+        $this->params = self::DEFAULT_PARAMS + [
+            'subscription-key' => $this->apiKey,
+            'query' => $query
+        ];
+
+        if ($categorySet) {
+            $this->params['categorySet'] = $categorySet;
+        }
+
+        return $this;
+    }
+
+    public function limit(int $limit): self
+    {
+        $this->params['limit'] = $limit;
+        return $this;
+    }
+
+    public function country(string|array $countryCode): self
+    {
+        $this->params['countrySet'] = is_array($countryCode)
+            ? implode(',', $countryCode)
+            : $countryCode;
+        return $this;
+    }
+
+    public function location(float $lat, float $lon, int $radius = 50000): self
+    {
+        $this->params['lat'] = $lat;
+        $this->params['lon'] = $lon;
+        $this->params['radius'] = $radius;
+        return $this;
+    }
+
+    public function get(): string
+    {
+        $response = Http::get($this->baseUrl, $this->params);
+
+        if ($response->failed()) {
+            throw new AzureMapsException('Failed to fetch search results');
+        }
+
+        return $this->formatResults($response->json());
+    }
+
+    private function formatResults(array $results): string
+    {
+        $formattedResults = collect($results['results'] ?? [])->map(function ($result) {
+            $address = $result['address'] ?? [];
+
+            $subdivision = isset($address['municipalitySubdivision']) ? $address['municipalitySubdivision'] . ', ' : '';
+            $municipality = $address['municipality'] ?? '';
+            $line2 = trim($subdivision . $municipality);
+
+            return [
+                'name' => $result['poi']['name'] ?? '',
+                'address' => [
+                    'line1' => trim(($address['streetNumber'] ?? '') . ' ' . ($address['streetName'] ?? '')),
+                    'line2' => $line2,
+                    'suburb' => $address['municipalitySubdivision'] ?? null,
+                    'city' => $address['municipality'] ?? null,
+                    'postalCode' => $address['postalCode'] ?? null,
+                    'province' => $address['countrySubdivision'] ?? null,
+                    'provinceCode' => $address['countrySubdivisionCode'] ?? null,
+                    'country' => $address['country'] ?? null,
+                    'countryCodeISO3' => $address['countryCodeISO3'] ?? null,
+                ],
+                'coordinates' => [
+                    'lat' => $result['position']['lat'] ?? null,
+                    'lng' => $result['position']['lon'] ?? null,
+                ],
+            ];
+        })->toArray();
+
+        return json_encode($formattedResults);
+    }
+}

--- a/src/Services/AzureMapsService.php
+++ b/src/Services/AzureMapsService.php
@@ -3,92 +3,27 @@
 namespace Sacapsystems\LaravelAzureMaps\Services;
 
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Http;
-use Sacapsystems\LaravelAzureMaps\Exceptions\AzureMapsException;
+use Sacapsystems\LaravelAzureMaps\Builders\QueryBuilder;
 
 class AzureMapsService
 {
-    private $baseUrl;
-    private $apiKey;
+    private QueryBuilder $queryBuilder;
 
     public function __construct()
     {
-        $this->baseUrl = Config::get('azure-maps.base_url');
-        $this->apiKey = Config::get('azure-maps.api_key');
+        $this->queryBuilder = new QueryBuilder(
+            Config::get('azure-maps.base_url'),
+            Config::get('azure-maps.api_key')
+        );
     }
 
-    /**
-     * @throws AzureMapsException
-     */
-    public function searchSchools($query, $limit = 5)
+    public function searchAddress(string $query): QueryBuilder
     {
-        return $this->search($query, $limit, '7372');
+        return $this->queryBuilder->newSearch($query);
     }
 
-    /**
-     * @throws AzureMapsException
-     */
-    public function searchAddress($query, $limit = 5)
+    public function searchSchools(string $query): QueryBuilder
     {
-        return $this->search($query, $limit);
-    }
-
-    /**
-     * @throws AzureMapsException
-     */
-    private function search($query, $limit, $categorySet = null)
-    {
-        $params = [
-            'api-version' => '1.0',
-            'subscription-key' => $this->apiKey,
-            'query' => $query,
-            'limit' => $limit,
-        ];
-
-        if ($categorySet) {
-            $params['categorySet'] = $categorySet;
-        }
-
-        $response = Http::get($this->baseUrl, $params);
-
-        if ($response->failed()) {
-            throw new AzureMapsException('Failed to fetch search results');
-        }
-
-        $results = $response->json('summary.numResults') > 0
-            ? $this->formatResults($response->json())
-            : [];
-
-        return json_encode($results);
-    }
-
-    private function formatResults($data): array
-    {
-        return collect($data['results'] ?? [])->map(function ($result) {
-            $address = $result['address'] ?? [];
-
-            $subdivision = isset($address['municipalitySubdivision']) ? $address['municipalitySubdivision'] . ', ' : '';
-            $municipality = $address['municipality'] ?? '';
-            $line2 = trim($subdivision . $municipality);
-
-            return [
-                'name' => $result['poi']['name'] ?? '',
-                'address' => [
-                    'line1' => trim(($address['streetNumber'] ?? '') . ' ' . ($address['streetName'] ?? '')),
-                    'line2' => $line2,
-                    'suburb' => $address['municipalitySubdivision'] ?? null,
-                    'city' => $address['municipality'] ?? null,
-                    'postalCode' => $address['postalCode'] ?? null,
-                    'province' => $address['countrySubdivision'] ?? null,
-                    'provinceCode' => $address['countrySubdivisionCode'] ?? null,
-                    'country' => $address['country'] ?? null,
-                    'countryCodeISO3' => $address['countryCodeISO3'] ?? null,
-                ],
-                'coordinates' => [
-                    'lat' => $result['position']['lat'] ?? null,
-                    'lng' => $result['position']['lon'] ?? null,
-                ],
-            ];
-        })->toArray();
+        return $this->queryBuilder->newSearch($query, '7372');
     }
 }

--- a/tests/Unit/AzureMapsServiceTest.php
+++ b/tests/Unit/AzureMapsServiceTest.php
@@ -10,115 +10,155 @@ use Sacapsystems\LaravelAzureMaps\Tests\TestCase;
 class AzureMapsServiceTest extends TestCase
 {
     protected $service;
+    protected $mockResponse;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->service = new AzureMapsService();
+        $this->mockResponse = [
+           'summary' => ['numResults' => 1],
+           'results' => [
+               [
+                   'address' => [
+                       'streetNumber' => '123',
+                       'streetName' => 'Main Street',
+                       'municipality' => 'Cape Town',
+                       'countrySubdivision' => 'Western Cape',
+                       'countrySubdivisionCode' => 'WC',
+                       'country' => 'South Africa',
+                       'countryCodeISO3' => 'ZAF',
+                       'postalCode' => '8001',
+                       'municipalitySubdivision' => 'City Bowl',
+                   ],
+                   'position' => [
+                       'lat' => -33.925,
+                       'lon' => 18.424,
+                   ],
+                   'poi' => [
+                       'name' => 'Test Location',
+                   ],
+               ],
+           ],
+        ];
     }
 
-    public function testSearchAddress()
+    public function testBasicAddressSearch()
     {
-        Http::fake([
-            '*' => Http::response([
-                'summary' => ['numResults' => 1],
-                'results' => [
-                    [
-                        'address' => [
-                            'streetNumber' => '123',
-                            'streetName' => 'Main Street',
-                            'municipality' => 'Cape Town',
-                            'countrySubdivision' => 'Western Cape',
-                            'countrySubdivisionCode' => 'WC',
-                            'country' => 'South Africa',
-                            'countryCodeISO3' => 'ZAF',
-                            'postalCode' => '8001',
-                            'municipalitySubdivision' => 'City Bowl',
-                        ],
-                        'position' => [
-                            'lat' => -33.925,
-                            'lon' => 18.424,
-                        ],
-                        'poi' => [
-                            'name' => 'Test Location',
-                        ],
-                    ],
-                ],
-            ], 200),
-        ]);
+        Http::fake(['*' => Http::response($this->mockResponse, 200)]);
 
-        $result = json_decode($this->service->searchAddress('123 Main Street, Cape Town'), true);
+        $result = json_decode(
+            $this->service->searchAddress('123 Main Street')
+               ->get(),
+            true
+        );
 
-        $this->assertIsArray($result);
-        $this->assertCount(1, $result);
-        $this->assertEquals('Test Location', $result[0]['name']);
-        $this->assertEquals('123 Main Street', $result[0]['address']['line1']);
-        $this->assertEquals(-33.925, $result[0]['coordinates']['lat']);
-        $this->assertEquals(18.424, $result[0]['coordinates']['lng']);
+        $this->assertBasicResponseStructure($result);
+        Http::assertSent(function ($request) {
+            return $request['query'] === '123 Main Street'
+               && $request['limit'] === 5;
+        });
     }
 
-    public function testSearchSchools()
+    public function testAddressSearchWithCustomLimit()
     {
-        Http::fake([
-            '*' => Http::response([
-                'summary' => ['numResults' => 1],
-                'results' => [
-                    [
-                        'address' => [
-                            'streetNumber' => '1',
-                            'streetName' => 'School Street',
-                            'municipality' => 'Cape Town',
-                            'countrySubdivision' => 'Western Cape',
-                            'countrySubdivisionCode' => 'WC',
-                            'country' => 'South Africa',
-                            'countryCodeISO3' => 'ZAF',
-                            'postalCode' => '8001',
-                            'municipalitySubdivision' => 'City Bowl',
-                        ],
-                        'position' => [
-                            'lat' => -33.925,
-                            'lon' => 18.424,
-                        ],
-                        'poi' => [
-                            'name' => 'Cape Town High School',
-                        ],
-                    ],
-                ],
-            ], 200),
-        ]);
+        Http::fake(['*' => Http::response($this->mockResponse, 200)]);
 
-        $result = json_decode($this->service->searchSchools('Cape Town High School'), true);
+        $result = json_decode(
+            $this->service->searchAddress('123 Main Street')
+               ->limit(10)
+               ->get(),
+            true
+        );
 
-        $this->assertIsArray($result);
-        $this->assertCount(1, $result);
-        $this->assertEquals('Cape Town High School', $result[0]['name']);
-        $this->assertEquals('1 School Street', $result[0]['address']['line1']);
+        Http::assertSent(function ($request) {
+            return $request['limit'] === 10;
+        });
     }
 
-    public function testSearchWithNoResults()
+    public function testAddressSearchWithSingleCountry()
     {
-        Http::fake([
-            '*' => Http::response([
-                'summary' => ['numResults' => 0],
-                'results' => [],
-            ], 200),
-        ]);
+        Http::fake(['*' => Http::response($this->mockResponse, 200)]);
 
-        $result = json_decode($this->service->searchAddress('NonexistentAddress'), true);
+        $this->service->searchAddress('123 Main Street')
+           ->country('ZA')
+           ->get();
 
-        $this->assertIsArray($result);
-        $this->assertEmpty($result);
+        Http::assertSent(function ($request) {
+            return $request['countrySet'] === 'ZA';
+        });
+    }
+
+    public function testAddressSearchWithMultipleCountries()
+    {
+        Http::fake(['*' => Http::response($this->mockResponse, 200)]);
+
+        $this->service->searchAddress('123 Main Street')
+           ->country(['ZA', 'NA'])
+           ->get();
+
+        Http::assertSent(function ($request) {
+            return $request['countrySet'] === 'ZA,NA';
+        });
+    }
+
+    public function testAddressSearchWithLocation()
+    {
+        Http::fake(['*' => Http::response($this->mockResponse, 200)]);
+
+        $this->service->searchAddress('123 Main Street')
+           ->location(-33.925, 18.424, 5000)
+           ->get();
+
+        Http::assertSent(function ($request) {
+            return $request['lat'] === -33.925
+               && $request['lon'] === 18.424
+               && $request['radius'] === 5000;
+        });
+    }
+
+    public function testSchoolSearch()
+    {
+        Http::fake(['*' => Http::response($this->mockResponse, 200)]);
+
+        $this->service->searchSchools('Cape Town High')
+           ->limit(5)
+           ->get();
+
+        Http::assertSent(function ($request) {
+            return $request['categorySet'] === '7372';
+        });
     }
 
     public function testSearchWithError()
     {
-        Http::fake([
-            '*' => Http::response([], 500),
-        ]);
+        Http::fake(['*' => Http::response([], 500)]);
 
         $this->expectException(AzureMapsException::class);
-        $this->expectExceptionMessage('Failed to fetch search results');
+        $this->service->searchAddress('Test')->get();
+    }
 
-        $this->service->searchAddress('Test Address');
+    public function testSearchWithNoResults()
+    {
+        Http::fake(['*' => Http::response([
+           'summary' => ['numResults' => 0],
+           'results' => []
+        ], 200)]);
+
+        $result = json_decode(
+            $this->service->searchAddress('NonexistentAddress')->get(),
+            true
+        );
+
+        $this->assertEmpty($result);
+    }
+
+    private function assertBasicResponseStructure($result)
+    {
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertArrayHasKey('name', $result[0]);
+        $this->assertArrayHasKey('address', $result[0]);
+        $this->assertArrayHasKey('coordinates', $result[0]);
     }
 }


### PR DESCRIPTION
This pull request introduces several significant changes to the `LaravelAzureMaps` package, including the addition of a new `QueryBuilder` class for constructing and executing queries, updates to the `AzureMapsService` class to utilize this new builder, and enhancements to the test suite.

### Major Changes:

**Introduction of `QueryBuilder`:**

* [`src/Builders/QueryBuilder.php`](diffhunk://#diff-510b34d9d297657bcde77316e1b12c4f8ddf4ca4f756de78e433743f8ca37339R1-R106): Added a new `QueryBuilder` class to handle the construction and execution of queries to the Azure Maps API. This class includes methods for setting query parameters, such as `limit`, `country`, and `location`, and a `get` method to execute the query and format the results.

**Refactoring `AzureMapsService`:**

* [`src/Services/AzureMapsService.php`](diffhunk://#diff-a3daa04da54c262c231354fccecf409da6f86acb7e30a51afc1a9ed939165939L6-R27): Refactored the `AzureMapsService` class to use the new `QueryBuilder` for constructing and executing queries. This change simplifies the service class by removing the direct HTTP request logic and delegating it to the `QueryBuilder`.

**Enhancements to the README:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R102): Updated the usage examples to reflect the new method chaining syntax enabled by the `QueryBuilder`. This includes examples of how to set custom limits, search multiple countries, and retrieve results.

**Improvements to Unit Tests:**

* [`tests/Unit/AzureMapsServiceTest.php`](diffhunk://#diff-6cb8180cd88433308e5110d8f63e92177fd9495968a402dbf1e02733545a9095R13-R19): Enhanced the unit tests to cover the new functionality provided by the `QueryBuilder`, including tests for basic address searches, custom limits, multiple country searches, and location-based searches. The tests now also include assertions to verify the structure of the response. [[1]](diffhunk://#diff-6cb8180cd88433308e5110d8f63e92177fd9495968a402dbf1e02733545a9095R13-R19) [[2]](diffhunk://#diff-6cb8180cd88433308e5110d8f63e92177fd9495968a402dbf1e02733545a9095L47-R162)